### PR TITLE
Modify named imports for unused variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 // Vendor
 import * as angular from 'angular';
 import 'angular-ui-router';
-import jquery from 'jquery';
-import material from 'angular-material';
+import 'jquery';
+import 'angular-material';
 
 // Style
 import '../node_modules/angular-material/angular-material.css';
-
 
 // Config
 import Config from './config';


### PR DESCRIPTION
Don't assign `jquery` and `angular-material` to variables since they're not needed elsewhere in the file.
